### PR TITLE
Add new response action for trusted communities

### DIFF
--- a/response_actions/RA_1014_connect_with_trusted_communities.yml
+++ b/response_actions/RA_1014_connect_with_trusted_communities.yml
@@ -1,0 +1,15 @@
+title: RA_1014_connect_with_trusted_communities
+id: RA1014
+description: Connect with trusted communities for information exchange
+author: Andreas Hunkeler (@Karneades)
+creation_date: 2020-05-14
+stage: preparation
+references: 
+  - https://www.misp-project.org/
+requirements:
+  - MISP connection to other teams or working on the MISP instance of another institution
+  - Mailing list
+  - Slack channel
+workflow: |
+  Contact other companies or information providers for getting on
+  a ML or get connected to other MISP instances.

--- a/response_actions/RA_1014_connect_with_trusted_communities.yml
+++ b/response_actions/RA_1014_connect_with_trusted_communities.yml
@@ -2,7 +2,7 @@ title: RA_1014_connect_with_trusted_communities
 id: RA1014
 description: Connect with trusted communities for information exchange
 author: Andreas Hunkeler (@Karneades)
-creation_date: 2020-05-14
+creation_date: 14.05.2020
 stage: preparation
 references: 
   - https://www.misp-project.org/
@@ -11,5 +11,4 @@ requirements:
   - Mailing list
   - Slack channel
 workflow: |
-  Contact other companies or information providers for getting on
-  a ML or get connected to other MISP instances.
+  Contact other companies or information providers for getting on a ML or get connected to other MISP instances.


### PR DESCRIPTION
Add new RA for connecting with trusted communities, like MISP. Hope the format and everything's ok and I included all relevant information for a new RA.

After adding my first RA action to see how that works, the following things came up:
- why do we have the category only inside the ID but the stage also in the RA itself? Or completely come away from the ID and only use the words inside the RA for both stage and category?
- we have the ID on three places (filename, id, title) - could we reduce that to one place?
- we have the filename the same like in the title inside the RA itself - could we reduce that information to one place? filename only an ID or skip the title if it's the same, ...? (maybe that's only because the rules are in dev...?)
- date format, I used the international notion (used too in Sigma rules) with `YYYY-MM-DD`, in the template was another format used (minor issue)
- using an additional number besides stage and category for RA's seams a bit of a hassle, if we also have unique file names, adding a new RA would also force one to lookup up the next number...I think it would be too much for the limited amount of RA's to add an UUID like it was introduced with the evolution of Sigma rules. Also using sequential numbers if a RA would be deleted then gaps would come up (minor issue).