### PR TITLE
Add various response actions for identification stage

### DIFF
--- a/response_actions/RA_2117_search_for_user-agent.yml
+++ b/response_actions/RA_2117_search_for_user-agent.yml
@@ -1,0 +1,11 @@
+title: RA_2117_search_for_user-agent.yml
+id: RA2117
+description: >
+  Search for specific user agent in your network logs.
+author: 'Andreas Hunkeler (@Karneades)'
+creation_date: 15.05.2020
+stage: identification
+requirements:
+  - DN_proxy_logs
+workflow: |
+  Get suspicious user agent and search for that specific user agent in your network logs.

--- a/response_actions/RA_2118_get_referrer_for_web_request.yml
+++ b/response_actions/RA_2118_get_referrer_for_web_request.yml
@@ -1,0 +1,11 @@
+title: RA_2118_get_referrer_for_web_request.yml
+id: RA2118
+description: >
+  Get the specific referrer from your network logs for a web request
+author: 'Andreas Hunkeler (@Karneades)'
+creation_date: 15.05.2020
+stage: identification
+requirements:
+  - DN_proxy_logs
+workflow: |
+  If you have a malicous redirect get the referrer from your network logs to find the compromised host.

--- a/response_actions/RA_2206_search_email_attributes_inside_mailboxes.yml
+++ b/response_actions/RA_2206_search_email_attributes_inside_mailboxes.yml
@@ -1,0 +1,11 @@
+title: RA_2206_search_email_attributes_inside_mailboxes
+id: RA2206
+description: >
+  Search for email attributes inside all of your mailboxes
+author: 'Andreas Hunkeler (@Karneades)'
+creation_date: 15.05.2020
+stage: identification
+requirements:
+  - DN_email_server
+workflow: |
+  Build query to search in all mailboxes for suspicious attributes, like forwarding rules.

--- a/response_actions/RA_2407_list_process_injections.yml
+++ b/response_actions/RA_2407_list_process_injections.yml
@@ -1,0 +1,12 @@
+title: RA_2407_list_process_injections.yml
+id: RA2407
+description: >
+  List processes injections on a particular system.
+author: 'Andreas Hunkeler (@Karneades)'
+creation_date: 15.05.2020
+stage: identification
+references: 
+  - https://attack.mitre.org/techniques/T1055/
+workflow: |
+  Use various information, like API calls, parent/child process dependencies
+  or process detection techniques to detect malicious behavior.

--- a/response_actions/RA_2602_list_local_accounts.yml
+++ b/response_actions/RA_2602_list_local_accounts.yml
@@ -1,0 +1,12 @@
+title: RA_2602_list_local_accounts
+id: RA2602
+description: >
+  List local accounts on a particular system
+author: 'Andreas Hunkeler (@Karneades)'
+creation_date: 15.05.2020
+stage: identification
+workflow: |
+  Get local accounts from a particular system.
+  This should be used to detect malicious accounts on that system.
+
+  Special focus shoud be on administrators and root accounts.

--- a/response_actions/RA_2603_list_logins_for_a_user.yml
+++ b/response_actions/RA_2603_list_logins_for_a_user.yml
@@ -1,0 +1,11 @@
+title: RA_2603_list_logins_for_a_user.yml
+id: RA2603
+description: >
+  List logins on remote systems for a specific user.
+author: 'Andreas Hunkeler (@Karneades)'
+creation_date: 15.05.2020
+stage: identification
+workflow: |
+  Get username for the user in questions and list all logins on other remote systems.
+
+  Look at the past and detect anomalies in login events.


### PR DESCRIPTION
This RA's for identifications were added
* User agent search
* Referrer search
* Email attributes search
* List process injections
* List local accounts
* List user logins on remote systems

I was wondering in which category one would put "context analysis" or "OSINT" actions, e.g. look for leaked credentials in Github, pastebin, ... as an action after a compromised account.

Maybe I should wait adding more actions until the numbering and the fields are clear for the files. What do you think? For me I would prefer only using names inside the action files instead of numbers for stage and category. Both are directly visible on the matrix when looking up existing actions.