### PR TITLE
Adding the hive task asignee functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _*
 # Ignore local configuration
 config.yml
 site/
+
+*atc_env/*

--- a/response_actions/respose_action.yml.template
+++ b/response_actions/respose_action.yml.template
@@ -1,21 +1,22 @@
 title: RA_0000_some_name_here
 id: RA0000  # define the ID based on this guideline: https://github.com/atc-project/atc-react#response-action
+owner: demisto # define theHive task Asignee
 description: >
   Response Action for doing something.
   This part will be merged into one line.
 author: your name/nickname/twitter
 creation_date: YYYY/MM/DD
 stage: identification # preparation / containment / eradication / recovery / lessons_learned
-automation: 
+automation:
   - thehive
   - demisto
   - phantom
   - etc
-references: 
+references:
   - https://example.com
 requirements:
   - MS_something # link to the Mitigation System required for the Response Action
   - DN_something # link to the Data Needed entity, required for the Response Action
 workflow: |
   Description of the workflow in the [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) format.
-  Here newlines will be saved.  
+  Here newlines will be saved.

--- a/scripts/atc_thehive/thehive_classes.py
+++ b/scripts/atc_thehive/thehive_classes.py
@@ -96,6 +96,7 @@ class TheHiveTask:
         self.title = ""
         self.group = group
         self.description = ""  # Can be omitted, supports markdown
+        self.owner = ""
 
     def validate(self):
         """Check if the mandatory fields are filled.
@@ -112,7 +113,8 @@ class TheHiveTask:
                 and self.order >= 0 \
                 and isinstance(self.title, str) \
                 and isinstance(self.group, str) \
-                and isinstance(self.description, str):
+                and isinstance(self.description, str) \
+                and isinstance(self.owner, str):
             fieldTypesCheck = True
 
         if mandatoryCheck and fieldTypesCheck:
@@ -130,6 +132,7 @@ class TheHiveTask:
             "title": self.title,
             "group": self.group,
             "description": self.description,
+            "owner": self.owner
         }
 
         return bigDict

--- a/scripts/atc_thehive/thehive_classes.py
+++ b/scripts/atc_thehive/thehive_classes.py
@@ -113,8 +113,7 @@ class TheHiveTask:
                 and self.order >= 0 \
                 and isinstance(self.title, str) \
                 and isinstance(self.group, str) \
-                and isinstance(self.description, str) \
-                and isinstance(self.owner, str):
+                and isinstance(self.description, str):
             fieldTypesCheck = True
 
         if mandatoryCheck and fieldTypesCheck:

--- a/scripts/thehive_templates.py
+++ b/scripts/thehive_templates.py
@@ -127,7 +127,7 @@ class RPTheHive:
         self.task_order = 0
 
         stages = [
-           'preparation', 'identification',  'containment', 'eradication', 
+           'preparation', 'identification',  'containment', 'eradication',
            'recovery', 'lessons_learned'
         ]
 
@@ -157,7 +157,7 @@ class RPTheHive:
                 task.title = str(self.task_prefix) + " | "\
                     + rtask.get('id')\
                     + ": "\
-                    + REACTutils.normalize_react_title(rtask.get('title')) 
+                    + REACTutils.normalize_react_title(rtask.get('title'))
 
                 if rtask.get('stage'):
                     task.group = REACTutils.normalize_rs_name(rtask.get('stage'))
@@ -165,6 +165,8 @@ class RPTheHive:
                     task.group = 'Unknown stage'
 
                 task.description = str(rtask.get('workflow'))
+                if rtask.get('owner'):
+                    task.owner = str(rtask.get('owner'))
                 self.case.tasks.append(task.return_dictionary())
 
     def checkSeverity(self, severity):


### PR DESCRIPTION
This PR will an extra field on the Response Actions yaml files to include the `owner` field as requested in the theHive [task model definition](https://github.com/TheHive-Project/TheHiveDocs/blob/master/api/task.md). This translates on theHive UI as the `Asignee` as we can see on the following screenshot:

<img width="727" alt="Screenshot 2021-02-22 at 16 52 38" src="https://user-images.githubusercontent.com/10466564/108733241-a01afa00-752e-11eb-9a58-1d9eb8ad4f92.png">

The motivation behind it, is on this case, tasks can be allocated to users in the hive (that in some cases can translate to automation).