### PR TITLE
RA2602: create RA for account listing

### DIFF
--- a/response_actions/RA_2601_list_accounts.yml
+++ b/response_actions/RA_2601_list_accounts.yml
@@ -10,9 +10,5 @@ automation:
 references:
   - https://example.com
 workflow: |
-  List accounts on a particular system or on all of your systems.
-  This could be done using system tools or reading account configuration.
-  
-  * Linux: cat /etc/shadows
-  * Windows: net user
-  * Or using artifact collection tools to get an account listing
+  List accounts on a particular system to get an overview of 
+  the available accounts.

--- a/response_actions/RA_2601_list_accounts.yml
+++ b/response_actions/RA_2601_list_accounts.yml
@@ -5,10 +5,9 @@ description: >
 author: Andreas Hunkeler/@Karneades
 creation_date: 2021/05/21
 stage: identification
-automation:
-  - thehive
 references:
-  - https://example.com
+  - Valid Accounts, https://attack.mitre.org/techniques/T1078/
+  - Account Manipulation, https://attack.mitre.org/techniques/T1098/
 workflow: |
   List accounts on a particular system to get an overview of 
   the available accounts.

--- a/response_actions/RA_2601_list_accounts.yml
+++ b/response_actions/RA_2601_list_accounts.yml
@@ -1,0 +1,18 @@
+title: RA_2602_list_accounts
+id: RA2602
+description: >
+  List accounts on a particular system
+author: Andreas Hunkeler/@Karneades
+creation_date: 2021/05/21
+stage: identification
+automation:
+  - thehive
+references:
+  - https://example.com
+workflow: |
+  List accounts on a particular system or on all of your systems.
+  This could be done using system tools or reading account configuration.
+  
+  * Linux: cat /etc/shadows
+  * Windows: net user
+  * Or using artifact collection tools to get an account listing


### PR DESCRIPTION
During identification it can be needed to list accounts on a system. This is used in parallel to RA2602 "List users authenticated".